### PR TITLE
Fewer api calls

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -18,9 +18,9 @@ const selectedArea = ref(null)
 
 // Track API call conditions
 const lastApiCallLocation = ref(null)
-const kWhPerYearPerHectare = ref(1850)
+const MWhPerYearPerHectare = ref(1850)
 const carbonOffsetPerYearPerHectare = ref(650)
-const kmDiff = ref(20) // Distance in kilometers before making a new API call
+const kmDiff = ref(50) // Distance in kilometers before making a new API call
 
 const calculatePotential = async (loc) => {
   isLoading.value = true
@@ -63,10 +63,10 @@ const calculatePotential = async (loc) => {
     calculationResult.value = data
     
     lastApiCallLocation.value = loc
-    kWhPerYearPerHectare.value = data.energyProduction
+    MWhPerYearPerHectare.value = data.energyProduction
     carbonOffsetPerYearPerHectare.value = data.carbonOffset
     console.log('coefficients updated:', {
-      kWh: kWhPerYearPerHectare.value,
+      kWh: MWhPerYearPerHectare.value,
       carbon: carbonOffsetPerYearPerHectare.value
     })
   } catch (e) {
@@ -103,7 +103,7 @@ const handleDrawEnd = (event) => {
     // Convert selected area to number of 1000 sqm units
     const areaHectares = selectedArea.value / 10000 // Convert to hectares
     calculationResult.value = {
-      energyProduction: areaHectares * kWhPerYearPerHectare.value,
+      energyProduction: areaHectares * MWhPerYearPerHectare.value,
       carbonOffset: areaHectares * carbonOffsetPerYearPerHectare.value
     }
   }
@@ -113,7 +113,7 @@ const handleCenterChange = (event) => {
     longitude.value = event.target.getCenter()[0];
     latitude.value = event.target.getCenter()[1];
     zoom.value = event.target.getZoom();
-    console.log('current coefficients', kWhPerYearPerHectare.value, carbonOffsetPerYearPerHectare.value)
+    console.log('current coefficients', MWhPerYearPerHectare.value, carbonOffsetPerYearPerHectare.value)
 }
 
 </script>
@@ -160,7 +160,7 @@ const handleCenterChange = (event) => {
             <CalculationResults 
               v-if="selectedArea"
               :area="selectedArea"
-              :kWh-per-year-per-hectare="kWhPerYearPerHectare"
+              :kWh-per-year-per-hectare="MWhPerYearPerHectare"
               :carbon-offset-per-year-per-hectare="carbonOffsetPerYearPerHectare"
             />
           </div>

--- a/client/src/components/CalculationResults.vue
+++ b/client/src/components/CalculationResults.vue
@@ -3,7 +3,7 @@
     <div class="main-result">
       <p>
         With your <span class="highlight">{{ formatArea(area) }}</span> of solar panels,
-        you would produce <span class="highlight">{{ (area / 10000 * kWhPerYearPerHectare).toFixed(2) }} MWh</span> per year.
+        you would produce <span class="highlight">{{ (area / 10000 * MWhPerYearPerHectare).toFixed(2) }} MWh</span> per year.
       </p>
     </div>
 
@@ -21,7 +21,7 @@ defineProps({
     type: Number,
     required: true
   },
-  kWhPerYearPerHectare: {
+  MWhPerYearPerHectare: {
     type: Number,
     required: true
   },

--- a/client/src/components/CalculationResults.vue
+++ b/client/src/components/CalculationResults.vue
@@ -1,15 +1,15 @@
 <template>
-  <div v-if="result" class="calculation-results">
+  <div v-if="area" class="calculation-results">
     <div class="main-result">
       <p>
-        With your <span class="highlight">{{ formatArea(result.areaHectares * 10000) }}</span> of solar panels,
-        you would produce <span class="highlight">{{ result.energyProduction.toFixed(2) }} MWh</span> per year.
+        With your <span class="highlight">{{ formatArea(area) }}</span> of solar panels,
+        you would produce <span class="highlight">{{ (area / 10000 * kWhPerYearPerHectare).toFixed(2) }} MWh</span> per year.
       </p>
     </div>
 
     <div class="context">
       <p class="carbon-offset">
-        Carbon offset: {{ result.carbonOffset.toFixed(1) }} tons CO₂e per year. <br> <span id="carbon-metaphor">Equivalent to {{ carbonMetaphor(result.carbonOffset) }}. </span>
+        Carbon offset: {{ (area /10000 * carbonOffsetPerYearPerHectare).toFixed(1) }} tons CO₂e per year. <br> <span id="carbon-metaphor">Equivalent to {{ carbonMetaphor(area / 10000 * carbonOffsetPerYearPerHectare) }}. </span>
       </p>
     </div>
   </div>
@@ -17,8 +17,16 @@
 
 <script setup>
 defineProps({
-  result: {
-    type: Object,
+  area: {
+    type: Number,
+    required: true
+  },
+  kWhPerYearPerHectare: {
+    type: Number,
+    required: true
+  },
+  carbonOffsetPerYearPerHectare: {
+    type: Number,
     required: true
   }
 })
@@ -27,7 +35,7 @@ const formatArea = (areaInSqMeters) => {
   if (areaInSqMeters >= 10000) {
     return `${(areaInSqMeters / 10000).toFixed(2)} hectares`
   }
-  return `${areaInSqMeters.toFixed(0)} sq. meters`
+  return `${areaInSqMeters} sq. meters`
 }
 
 const carbonMetaphor = (effectiveCarbon) => {

--- a/client/src/components/CalculationResults.vue
+++ b/client/src/components/CalculationResults.vue
@@ -35,14 +35,14 @@ const formatArea = (areaInSqMeters) => {
   if (areaInSqMeters >= 10000) {
     return `${(areaInSqMeters / 10000).toFixed(2)} hectares`
   }
-  return `${areaInSqMeters} sq. meters`
+  return `${areaInSqMeters.toFixed(2)} sq. meters`
 }
 
 const carbonMetaphor = (effectiveCarbon) => {
   // Array of carbon equivalencies with their coefficients and descriptions
   const carbonEquivalencies = [
     {
-      verb: 'stopping',
+      verb: 'skipping',
       activity: 'transatlantic flights',
       coefficient: 1, // source: Aarathi :)
     },


### PR DESCRIPTION
- before we make an API call, we check if the last API call was made from a lat/long 50km or less
- fixed some weird hectare math going on; I think the numbers are correct now
- CalculationResult updates dynamically with the solar panel area without any additional API calls being made.


Right now it requires that the user set their location in order to get the right MWh and carbon coefficients. I tried to make it call `calculatePotential`  as soon as the user starts drawing, but it messed with that interaction in a weird way